### PR TITLE
Fix bug and add required meta tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,14 @@ function iosPWASplash(icon, color = 'white') {
         const imageDataURL = canvas.toDataURL('image/png');
         const imageDataURL2 = canvas2.toDataURL('image/png');
 
+        // Add apple-mobile-web-app-capable if not already present
+        if (!document.querySelector('meta[name="apple-mobile-web-app-capable"]')) {
+            const metaTag = document.createElement('meta');
+            metaTag.setAttribute('name', 'apple-mobile-web-app-capable');
+            metaTag.setAttribute('content', 'yes');
+            document.head.appendChild(metaTag);
+        }
+
         // Create the first startup image <link> tag (splash screen)
 
         const appleTouchStartupImageLink = document.createElement('link');

--- a/index.js
+++ b/index.js
@@ -12,8 +12,20 @@ function iosPWASplash(icon, color = 'white') {
     }
 
     // Calculate the device's width and height
-    const deviceWidth = screen.width;
-    const deviceHeight = screen.height;
+    let deviceWidth = screen.width;
+    let deviceHeight = screen.height;
+
+    // The following detects the device's width and height in private mode 
+    if (window.visualViewport?.width) {
+        const deviceWidthPM = Math.round(window.visualViewport.width * window.visualViewport.scale);
+        // if not private mode, then both values should be equal so the code will not run
+        if (deviceWidth > deviceWidthPM) {
+            deviceWidth = deviceWidthPM;
+            // in private mode, uses the direct ratio to calculate the height since this is the only way as of now
+            deviceHeight = (284 / 131) * deviceWidth;
+        }
+    }
+
     // Calculate the pixel ratio
     const pixelRatio = window.devicePixelRatio || 1;
     // Create two canvases and get their contexts to draw landscape and portrait splash screens.


### PR DESCRIPTION
Fixes #3 for all devices since [iPhone 11](https://iosref.com/res).

The logic added will not break the code for any older devices, so it will only help. Although hard coding a ratio isn't perfect, it seems to be the only method to detect the height in private mode, as of now, and all devices since iPhone 11 have been using this ratio.

This PR also automatically adds the `apple-mobile-web-app-capable` if not already present, which is a required meta tag for the splash screen.